### PR TITLE
feat(proposal): add query use cases for proposals

### DIFF
--- a/modules/proposal-management/src/main/java/com/marketplace/proposal/adapter/input/rest/ProposalController.java
+++ b/modules/proposal-management/src/main/java/com/marketplace/proposal/adapter/input/rest/ProposalController.java
@@ -2,13 +2,17 @@ package com.marketplace.proposal.adapter.input.rest;
 
 import com.marketplace.proposal.application.dto.request.SubmitProposalRequest;
 import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import com.marketplace.proposal.application.port.input.FindProposalsByOpportunityUseCase;
+import com.marketplace.proposal.application.port.input.GetProposalUseCase;
 import com.marketplace.proposal.application.port.input.SubmitProposalUseCase;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -36,9 +40,17 @@ public class ProposalController {
     private static final Logger logger = LoggerFactory.getLogger(ProposalController.class);
     
     private final SubmitProposalUseCase submitProposalUseCase;
+    private final GetProposalUseCase getProposalUseCase;
+    private final FindProposalsByOpportunityUseCase findProposalsByOpportunityUseCase;
     
-    public ProposalController(SubmitProposalUseCase submitProposalUseCase) {
+    public ProposalController(
+        SubmitProposalUseCase submitProposalUseCase,
+        GetProposalUseCase getProposalUseCase,
+        FindProposalsByOpportunityUseCase findProposalsByOpportunityUseCase
+    ) {
         this.submitProposalUseCase = submitProposalUseCase;
+        this.getProposalUseCase = getProposalUseCase;
+        this.findProposalsByOpportunityUseCase = findProposalsByOpportunityUseCase;
     }
     
     /**
@@ -77,8 +89,11 @@ public class ProposalController {
     public Mono<ProposalResponse> getProposal(@PathVariable Long proposalId) {
         logger.info("Received request to get proposal: proposalId={}", proposalId);
         
-        // TODO: Implement GetProposalUseCase
-        return Mono.empty();
+        return getProposalUseCase.execute(proposalId)
+            .switchIfEmpty(Mono.error(new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                "Proposal not found"
+            )));
     }
     
     /**
@@ -91,11 +106,10 @@ public class ProposalController {
         value = "/opportunity/{opportunityId}",
         produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public Mono<ProposalResponse> getProposalsForOpportunity(@PathVariable Long opportunityId) {
+    public Flux<ProposalResponse> getProposalsForOpportunity(@PathVariable Long opportunityId) {
         logger.info("Received request to get proposals for opportunityId: {}", opportunityId);
         
-        // TODO: Implement FindProposalsByOpportunityUseCase
-        return Mono.empty();
+        return findProposalsByOpportunityUseCase.execute(opportunityId);
     }
     
     /**

--- a/modules/proposal-management/src/main/java/com/marketplace/proposal/application/port/input/FindProposalsByOpportunityUseCase.java
+++ b/modules/proposal-management/src/main/java/com/marketplace/proposal/application/port/input/FindProposalsByOpportunityUseCase.java
@@ -1,0 +1,11 @@
+package com.marketplace.proposal.application.port.input;
+
+import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import reactor.core.publisher.Flux;
+
+/**
+ * Use Case for retrieving proposals by opportunity ID.
+ */
+public interface FindProposalsByOpportunityUseCase {
+    Flux<ProposalResponse> execute(Long opportunityId);
+}

--- a/modules/proposal-management/src/main/java/com/marketplace/proposal/application/port/input/GetProposalUseCase.java
+++ b/modules/proposal-management/src/main/java/com/marketplace/proposal/application/port/input/GetProposalUseCase.java
@@ -1,0 +1,11 @@
+package com.marketplace.proposal.application.port.input;
+
+import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * Use Case for retrieving a proposal by ID.
+ */
+public interface GetProposalUseCase {
+    Mono<ProposalResponse> execute(Long proposalId);
+}

--- a/modules/proposal-management/src/main/java/com/marketplace/proposal/application/usecase/FindProposalsByOpportunityUseCaseImpl.java
+++ b/modules/proposal-management/src/main/java/com/marketplace/proposal/application/usecase/FindProposalsByOpportunityUseCaseImpl.java
@@ -1,0 +1,45 @@
+package com.marketplace.proposal.application.usecase;
+
+import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import com.marketplace.proposal.application.port.input.FindProposalsByOpportunityUseCase;
+import com.marketplace.proposal.application.port.output.ProposalRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+/**
+ * Use Case implementation for retrieving proposals by opportunity.
+ */
+@Service
+public class FindProposalsByOpportunityUseCaseImpl implements FindProposalsByOpportunityUseCase {
+
+    private static final Logger logger = LoggerFactory.getLogger(FindProposalsByOpportunityUseCaseImpl.class);
+
+    private final ProposalRepository proposalRepository;
+
+    public FindProposalsByOpportunityUseCaseImpl(ProposalRepository proposalRepository) {
+        this.proposalRepository = proposalRepository;
+    }
+
+    @Override
+    public Flux<ProposalResponse> execute(Long opportunityId) {
+        return proposalRepository.findByOpportunityId(opportunityId)
+            .map(ProposalResponse::fromDomain)
+            .doOnComplete(() -> logComplete(opportunityId))
+            .doOnError(error -> logError(opportunityId, error));
+    }
+
+    private void logComplete(Long opportunityId) {
+        logger.info("Fetched proposals for opportunityId={}", opportunityId);
+    }
+
+    private void logError(Long opportunityId, Throwable error) {
+        logger.error(
+            "Failed to fetch proposals for opportunityId={}: {}",
+            opportunityId,
+            error.getMessage(),
+            error
+        );
+    }
+}

--- a/modules/proposal-management/src/main/java/com/marketplace/proposal/application/usecase/GetProposalUseCaseImpl.java
+++ b/modules/proposal-management/src/main/java/com/marketplace/proposal/application/usecase/GetProposalUseCaseImpl.java
@@ -1,0 +1,56 @@
+package com.marketplace.proposal.application.usecase;
+
+import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import com.marketplace.proposal.application.port.input.GetProposalUseCase;
+import com.marketplace.proposal.application.port.output.ProposalRepository;
+import com.marketplace.proposal.domain.valueobject.ProposalId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+/**
+ * Use Case implementation for retrieving proposals by ID.
+ */
+@Service
+public class GetProposalUseCaseImpl implements GetProposalUseCase {
+
+    private static final Logger logger = LoggerFactory.getLogger(GetProposalUseCaseImpl.class);
+
+    private final ProposalRepository proposalRepository;
+
+    public GetProposalUseCaseImpl(ProposalRepository proposalRepository) {
+        this.proposalRepository = proposalRepository;
+    }
+
+    @Override
+    public Mono<ProposalResponse> execute(Long proposalId) {
+        return Mono.fromCallable(() -> ProposalId.of(proposalId))
+            .flatMap(proposalRepository::findById)
+            .map(ProposalResponse::fromDomain)
+            .doOnSuccess(response -> logSuccess(proposalId, response))
+            .doOnError(error -> logError(proposalId, error));
+    }
+
+    private void logSuccess(Long proposalId, ProposalResponse response) {
+        if (response == null) {
+            logger.debug("Proposal not found: proposalId={}", proposalId);
+            return;
+        }
+
+        logger.info(
+            "Proposal retrieved successfully: proposalId={}, opportunityId={}",
+            response.proposalId(),
+            response.opportunityId()
+        );
+    }
+
+    private void logError(Long proposalId, Throwable error) {
+        logger.error(
+            "Failed to retrieve proposal: proposalId={}, error={}",
+            proposalId,
+            error.getMessage(),
+            error
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide read/query capabilities for proposals so the API can return proposal details and lists (by ID and by opportunity) required by clients.
- Follow the existing hexagonal design by introducing explicit use-case ports for queries instead of embedding repository calls in controllers.
- Ensure reactive return types and proper HTTP semantics for not-found cases on the proposal endpoints.

### Description
- Added new input ports `GetProposalUseCase` and `FindProposalsByOpportunityUseCase` as interfaces under `modules/proposal-management/src/main/java/com/marketplace/proposal/application/port/input`.
- Implemented `GetProposalUseCaseImpl` and `FindProposalsByOpportunityUseCaseImpl` under `modules/proposal-management/src/main/java/com/marketplace/proposal/application/usecase` that use the existing `ProposalRepository` and map domain models to `ProposalResponse`.
- Wired the new use cases into `ProposalController`: injected the services, changed `getProposalsForOpportunity` to return `Flux<ProposalResponse>`, and made `getProposal` return `Mono<ProposalResponse>` with 404 handling using `ResponseStatusException` when the result is empty.
- Updated imports and logging around the new code paths and reactive mappings to reuse existing `ProposalResponse::fromDomain` mapping.

### Testing
- No automated tests were executed as part of this change.
- Basic static code changes committed; no build or test commands were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe4d292c48332b92117106cb67da4)