### PR TITLE
Add starter unit tests for opportunity, proposal, and user modules

### DIFF
--- a/modules/opportunity-management/src/test/java/com/marketplace/opportunity/adapter/output/persistence/OpportunityEntityMapperTest.java
+++ b/modules/opportunity-management/src/test/java/com/marketplace/opportunity/adapter/output/persistence/OpportunityEntityMapperTest.java
@@ -1,0 +1,61 @@
+package com.marketplace.opportunity.adapter.output.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketplace.opportunity.domain.model.Opportunity;
+import com.marketplace.opportunity.domain.model.OpportunitySpecification;
+import com.marketplace.opportunity.domain.valueobject.Money;
+import com.marketplace.opportunity.domain.valueobject.OpportunityId;
+import com.marketplace.opportunity.domain.valueobject.OpportunityStatus;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Currency;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpportunityEntityMapperTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OpportunityEntityMapper mapper = new OpportunityEntityMapper(objectMapper);
+
+    @Test
+    void mapsBetweenDomainAndEntity() {
+        Opportunity opportunity = Opportunity.builder()
+            .id(OpportunityId.of(99L))
+            .consumerId(11L)
+            .tenantId(22L)
+            .title("Enterprise integration project")
+            .description("Need integration with existing ERP and CRM systems with full documentation.")
+            .category("Integration")
+            .budget(Money.of(BigDecimal.valueOf(5000), Currency.getInstance("USD")))
+            .deadline(Instant.now().plusSeconds(7200))
+            .status(OpportunityStatus.DRAFT)
+            .attachments(List.of("https://files.example.com/spec.pdf"))
+            .specification(OpportunitySpecification.withTemplate(Map.of("erp", "SAP"), "erp-template"))
+            .createdAt(Instant.now())
+            .updatedAt(Instant.now())
+            .build();
+
+        OpportunityEntity entity = mapper.toEntity(opportunity);
+
+        assertThat(entity.id()).isEqualTo(99L);
+        assertThat(entity.attachments()).containsExactly("https://files.example.com/spec.pdf");
+        assertThat(entity.templateKey()).isEqualTo("erp-template");
+
+        Opportunity mapped = mapper.toDomain(entity);
+
+        assertThat(mapped.id()).isEqualTo(opportunity.id());
+        assertThat(mapped.specification().templateKey()).isEqualTo("erp-template");
+        assertThat(mapped.specification().all()).containsEntry("erp", "SAP");
+    }
+
+    @Test
+    void deserializeAttachmentsReturnsEmptyListOnInvalidJson() {
+        List<String> attachments = mapper.deserializeAttachments("{invalid-json");
+
+        assertThat(attachments).isEmpty();
+    }
+}

--- a/modules/opportunity-management/src/test/java/com/marketplace/opportunity/application/usecase/CreateOpportunityUseCaseImplTest.java
+++ b/modules/opportunity-management/src/test/java/com/marketplace/opportunity/application/usecase/CreateOpportunityUseCaseImplTest.java
@@ -1,0 +1,85 @@
+package com.marketplace.opportunity.application.usecase;
+
+import com.marketplace.opportunity.application.port.output.EventPublisher;
+import com.marketplace.opportunity.application.port.output.OpportunityRepository;
+import com.marketplace.opportunity.domain.command.CreateOpportunityCommand;
+import com.marketplace.opportunity.domain.model.Opportunity;
+import com.marketplace.shared.infrastructure.id.SnowflakeIdGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateOpportunityUseCaseImplTest {
+
+    @Mock
+    private OpportunityRepository repository;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Mock
+    private SnowflakeIdGenerator idGenerator;
+
+    @Captor
+    private ArgumentCaptor<Opportunity> opportunityCaptor;
+
+    private CreateOpportunityUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateOpportunityUseCaseImpl(repository, eventPublisher, idGenerator);
+    }
+
+    @Test
+    void executeBuildsOpportunityAndPersists() {
+        when(idGenerator.nextId()).thenReturn(42L);
+        when(repository.save(any(Opportunity.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        CreateOpportunityCommand command = new CreateOpportunityCommand(
+            10L,
+            20L,
+            "New mobile app development",
+            "We need a new mobile app built with modern architecture and testing.",
+            "Software",
+            BigDecimal.valueOf(15000),
+            "USD",
+            Instant.now().plusSeconds(3600),
+            List.of("https://files.example.com/brief.pdf"),
+            Map.of("platform", "iOS"),
+            "mobile-app-template"
+        );
+
+        StepVerifier.create(useCase.execute(command))
+            .assertNext(opportunity -> {
+                assertThat(opportunity.id().value()).isEqualTo(42L);
+                assertThat(opportunity.title()).isEqualTo(command.title());
+                assertThat(opportunity.budget().currencyCode()).isEqualTo("USD");
+                assertThat(opportunity.attachments()).containsExactly("https://files.example.com/brief.pdf");
+                assertThat(opportunity.specification().templateKey()).isEqualTo("mobile-app-template");
+                assertThat(opportunity.specification().all()).containsEntry("platform", "iOS");
+            })
+            .verifyComplete();
+
+        verify(repository).save(opportunityCaptor.capture());
+        assertThat(opportunityCaptor.getValue().consumerId()).isEqualTo(command.consumerId());
+        verify(eventPublisher, never()).publishAll(any());
+    }
+}

--- a/modules/proposal-management/src/test/java/com/marketplace/proposal/adapter/output/persistence/ProposalEntityMapperTest.java
+++ b/modules/proposal-management/src/test/java/com/marketplace/proposal/adapter/output/persistence/ProposalEntityMapperTest.java
@@ -1,0 +1,73 @@
+package com.marketplace.proposal.adapter.output.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketplace.proposal.domain.model.Proposal;
+import com.marketplace.proposal.domain.valueobject.DeliveryTime;
+import com.marketplace.proposal.domain.valueobject.ProposalId;
+import com.marketplace.shared.domain.valueobject.Money;
+import io.r2dbc.spi.Row;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class ProposalEntityMapperTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ProposalEntityMapper mapper = new ProposalEntityMapper(objectMapper);
+
+    @Test
+    void toEntitySerializesCollections() throws Exception {
+        Proposal proposal = Proposal.create(
+            ProposalId.of(77L),
+            44L,
+            33L,
+            22L,
+            Money.of(BigDecimal.valueOf(900), "USD"),
+            DeliveryTime.fromDaysAndHours(3, 5),
+            "A detailed proposal describing the approach, deliverables, and timeline for delivery."
+        );
+        proposal.addAttachment("https://files.example.com/quote.pdf");
+        proposal.addSpecification("service", "Design");
+
+        ProposalEntity entity = mapper.toEntity(proposal);
+
+        List<String> attachments = objectMapper.readValue(entity.attachmentsJson(), new TypeReference<>() {});
+        Map<String, Object> specifications = objectMapper.readValue(entity.specificationsJson(), new TypeReference<>() {});
+
+        assertThat(entity.id()).isEqualTo(77L);
+        assertThat(attachments).containsExactly("https://files.example.com/quote.pdf");
+        assertThat(specifications).containsEntry("service", "Design");
+    }
+
+    @Test
+    void fromRowRestoresAttachmentsAndSpecifications() {
+        Row row = Mockito.mock(Row.class);
+
+        when(row.get("id", Long.class)).thenReturn(88L);
+        when(row.get("opportunity_id", Long.class)).thenReturn(55L);
+        when(row.get("company_id", Long.class)).thenReturn(66L);
+        when(row.get("tenant_id", Long.class)).thenReturn(77L);
+        when(row.get("price_amount", BigDecimal.class)).thenReturn(BigDecimal.valueOf(1500));
+        when(row.get("price_currency", String.class)).thenReturn("USD");
+        when(row.get("delivery_days", Integer.class)).thenReturn(2);
+        when(row.get("delivery_hours", Integer.class)).thenReturn(4);
+        when(row.get("description", String.class))
+            .thenReturn("Proposal description with enough detail to satisfy validation length.");
+        when(row.get("attachments", String.class)).thenReturn("[\"https://files.example.com/specs.pdf\"]");
+        when(row.get("specifications", String.class)).thenReturn("{\"tool\":\"Figma\"}");
+
+        Proposal proposal = mapper.fromRow(row);
+
+        assertThat(proposal.getProposalId()).isEqualTo(ProposalId.of(88L));
+        assertThat(proposal.getAttachments()).containsExactly("https://files.example.com/specs.pdf");
+        assertThat(proposal.getSpecifications()).containsEntry("tool", "Figma");
+    }
+}

--- a/modules/proposal-management/src/test/java/com/marketplace/proposal/application/usecase/SubmitProposalUseCaseImplTest.java
+++ b/modules/proposal-management/src/test/java/com/marketplace/proposal/application/usecase/SubmitProposalUseCaseImplTest.java
@@ -1,0 +1,81 @@
+package com.marketplace.proposal.application.usecase;
+
+import com.marketplace.proposal.application.dto.request.SubmitProposalRequest;
+import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import com.marketplace.proposal.application.port.output.ProposalRepository;
+import com.marketplace.proposal.domain.model.Proposal;
+import com.marketplace.proposal.domain.service.ProposalValidationChain;
+import com.marketplace.shared.infrastructure.id.SnowflakeIdGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SubmitProposalUseCaseImplTest {
+
+    @Mock
+    private ProposalRepository proposalRepository;
+
+    @Mock
+    private ProposalValidationChain validationChain;
+
+    @Mock
+    private SnowflakeIdGenerator idGenerator;
+
+    @Captor
+    private ArgumentCaptor<Proposal> proposalCaptor;
+
+    private SubmitProposalUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new SubmitProposalUseCaseImpl(proposalRepository, validationChain, idGenerator);
+    }
+
+    @Test
+    void executeCreatesProposalAndReturnsResponse() {
+        when(idGenerator.nextId()).thenReturn(1001L);
+        when(proposalRepository.save(any(Proposal.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        SubmitProposalRequest request = new SubmitProposalRequest(
+            55L,
+            BigDecimal.valueOf(1200),
+            "USD",
+            5,
+            4,
+            "Detailed proposal covering requirements, timeline, and delivery milestones for the project.",
+            List.of("https://files.example.com/portfolio.pdf"),
+            Map.of("stack", "Spring")
+        );
+
+        StepVerifier.create(useCase.execute(request))
+            .assertNext(response -> {
+                assertThat(response).isInstanceOf(ProposalResponse.class);
+                assertThat(response.opportunityId()).isEqualTo(request.opportunityId());
+                assertThat(response.companyId()).isEqualTo(1L);
+            })
+            .verifyComplete();
+
+        verify(validationChain).validate(any());
+        verify(proposalRepository).save(proposalCaptor.capture());
+        assertThat(proposalCaptor.getValue().getAttachments())
+            .containsExactly("https://files.example.com/portfolio.pdf");
+        assertThat(proposalCaptor.getValue().getSpecifications())
+            .containsEntry("stack", "Spring");
+    }
+}

--- a/modules/user-management/src/test/java/com/marketplace/user/domain/valueobject/EmailTest.java
+++ b/modules/user-management/src/test/java/com/marketplace/user/domain/valueobject/EmailTest.java
@@ -1,0 +1,34 @@
+package com.marketplace.user.domain.valueobject;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EmailTest {
+
+    @Test
+    void ofNormalizesAndExtractsParts() {
+        Email email = Email.of("  John.Doe@Example.com ");
+
+        assertThat(email.toString()).isEqualTo("john.doe@example.com");
+        assertThat(email.getLocalPart()).isEqualTo("john.doe");
+        assertThat(email.getDomain()).isEqualTo("example.com");
+        assertThat(email.belongsToDomain("example.com")).isTrue();
+        assertThat(email.isCorporateEmail()).isTrue();
+    }
+
+    @Test
+    void ofRejectsInvalidEmail() {
+        assertThatThrownBy(() -> Email.of("invalid-email"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Invalid email format");
+    }
+
+    @Test
+    void getMaskedReturnsMaskedValue() {
+        Email email = Email.of("ab@example.com");
+
+        assertThat(email.getMasked()).isEqualTo("a***@example.com");
+    }
+}


### PR DESCRIPTION
### Motivation

- Start adding unit tests across core modules to follow testing best practices and increase confidence in domain logic.
- Cover important units including use cases, persistence mappers and value objects to prevent regressions early.
- Use lightweight isolated tests (no infra dependencies) so feedback is fast and deterministic.
- Prepare the project for CI by adding test classes and standard testing libraries in module test folders.

### Description

- Added test classes for core units: `modules/opportunity-management/src/test/java/com/marketplace/opportunity/application/usecase/CreateOpportunityUseCaseImplTest.java`, `modules/opportunity-management/src/test/java/com/marketplace/opportunity/adapter/output/persistence/OpportunityEntityMapperTest.java`, `modules/proposal-management/src/test/java/com/marketplace/proposal/application/usecase/SubmitProposalUseCaseImplTest.java`, `modules/proposal-management/src/test/java/com/marketplace/proposal/adapter/output/persistence/ProposalEntityMapperTest.java`, and `modules/user-management/src/test/java/com/marketplace/user/domain/valueobject/EmailTest.java`.
- Tests use `JUnit 5`, `Mockito` (with `MockitoExtension` and `ArgumentCaptor`), `AssertJ` assertions, Jackson `ObjectMapper` for JSON assertions and Reactor `StepVerifier` for reactive flows.
- External dependencies are mocked (e.g. `OpportunityRepository`, `ProposalRepository`, `SnowflakeIdGenerator`, `Row`) to keep tests unit-focused.
- Created corresponding test directories under each module to organize tests following the existing package layout.

### Testing

- No automated tests were executed as part of this change (CI/test run was not invoked).
- The added tests are standard JUnit tests and can be executed via Maven, for example `mvn -pl modules/opportunity-management test` (or run module-level `mvn test` for each module).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645a8325b08332b00b1489010edda7)