### PR TITLE
🧹 [code health improvement] Implement AcceptProposalUseCase

### DIFF
--- a/modules/proposal-management/src/main/java/com/marketplace/proposal/adapter/input/rest/ProposalController.java
+++ b/modules/proposal-management/src/main/java/com/marketplace/proposal/adapter/input/rest/ProposalController.java
@@ -2,6 +2,7 @@ package com.marketplace.proposal.adapter.input.rest;
 
 import com.marketplace.proposal.application.dto.request.SubmitProposalRequest;
 import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import com.marketplace.proposal.application.port.input.AcceptProposalUseCase;
 import com.marketplace.proposal.application.port.input.FindProposalsByOpportunityUseCase;
 import com.marketplace.proposal.application.port.input.GetProposalUseCase;
 import com.marketplace.proposal.application.port.input.SubmitProposalUseCase;
@@ -42,15 +43,18 @@ public class ProposalController {
     private final SubmitProposalUseCase submitProposalUseCase;
     private final GetProposalUseCase getProposalUseCase;
     private final FindProposalsByOpportunityUseCase findProposalsByOpportunityUseCase;
+    private final AcceptProposalUseCase acceptProposalUseCase;
     
     public ProposalController(
         SubmitProposalUseCase submitProposalUseCase,
         GetProposalUseCase getProposalUseCase,
-        FindProposalsByOpportunityUseCase findProposalsByOpportunityUseCase
+        FindProposalsByOpportunityUseCase findProposalsByOpportunityUseCase,
+        AcceptProposalUseCase acceptProposalUseCase
     ) {
         this.submitProposalUseCase = submitProposalUseCase;
         this.getProposalUseCase = getProposalUseCase;
         this.findProposalsByOpportunityUseCase = findProposalsByOpportunityUseCase;
+        this.acceptProposalUseCase = acceptProposalUseCase;
     }
     
     /**
@@ -162,8 +166,19 @@ public class ProposalController {
     public Mono<ProposalResponse> acceptProposal(@PathVariable Long proposalId) {
         logger.info("Received request to accept proposal: proposalId={}", proposalId);
         
-        // TODO: Implement AcceptProposalUseCase
-        return Mono.empty();
+        return acceptProposalUseCase.execute(proposalId)
+            .switchIfEmpty(Mono.error(new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                "Proposal not found"
+            )))
+            .onErrorMap(IllegalStateException.class, e -> new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                e.getMessage()
+            ))
+            .onErrorMap(IllegalArgumentException.class, e -> new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                e.getMessage()
+            ));
     }
     
     /**

--- a/modules/proposal-management/src/main/java/com/marketplace/proposal/application/port/input/AcceptProposalUseCase.java
+++ b/modules/proposal-management/src/main/java/com/marketplace/proposal/application/port/input/AcceptProposalUseCase.java
@@ -1,0 +1,11 @@
+package com.marketplace.proposal.application.port.input;
+
+import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * Use Case for accepting a proposal by ID.
+ */
+public interface AcceptProposalUseCase {
+    Mono<ProposalResponse> execute(Long proposalId);
+}

--- a/modules/proposal-management/src/main/java/com/marketplace/proposal/application/usecase/AcceptProposalUseCaseImpl.java
+++ b/modules/proposal-management/src/main/java/com/marketplace/proposal/application/usecase/AcceptProposalUseCaseImpl.java
@@ -1,0 +1,46 @@
+package com.marketplace.proposal.application.usecase;
+
+import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import com.marketplace.proposal.application.port.input.AcceptProposalUseCase;
+import com.marketplace.proposal.application.port.output.ProposalRepository;
+import com.marketplace.proposal.domain.valueobject.ProposalId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+/**
+ * Use Case implementation for accepting a proposal by ID.
+ */
+@Service
+public class AcceptProposalUseCaseImpl implements AcceptProposalUseCase {
+
+    private static final Logger logger = LoggerFactory.getLogger(AcceptProposalUseCaseImpl.class);
+
+    private final ProposalRepository proposalRepository;
+
+    public AcceptProposalUseCaseImpl(ProposalRepository proposalRepository) {
+        this.proposalRepository = proposalRepository;
+    }
+
+    @Override
+    public Mono<ProposalResponse> execute(Long proposalId) {
+        return Mono.fromCallable(() -> ProposalId.of(proposalId))
+            .flatMap(proposalRepository::findById)
+            .flatMap(proposal -> {
+                try {
+                    proposal.accept();
+                    return proposalRepository.save(proposal);
+                } catch (Exception e) {
+                    return Mono.error(e);
+                }
+            })
+            .map(ProposalResponse::fromDomain)
+            .doOnSuccess(response -> {
+                if (response != null) {
+                    logger.info("Proposal accepted successfully: proposalId={}", proposalId);
+                }
+            })
+            .doOnError(error -> logger.error("Failed to accept proposal: proposalId={}, error={}", proposalId, error.getMessage(), error));
+    }
+}

--- a/modules/proposal-management/src/test/java/com/marketplace/proposal/application/usecase/AcceptProposalUseCaseImplTest.java
+++ b/modules/proposal-management/src/test/java/com/marketplace/proposal/application/usecase/AcceptProposalUseCaseImplTest.java
@@ -1,0 +1,101 @@
+package com.marketplace.proposal.application.usecase;
+
+import com.marketplace.proposal.application.dto.response.ProposalResponse;
+import com.marketplace.proposal.application.port.output.ProposalRepository;
+import com.marketplace.proposal.domain.model.Proposal;
+import com.marketplace.proposal.domain.valueobject.ProposalId;
+import com.marketplace.proposal.domain.valueobject.ProposalStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AcceptProposalUseCaseImplTest {
+
+    @Mock
+    private ProposalRepository proposalRepository;
+
+    private AcceptProposalUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new AcceptProposalUseCaseImpl(proposalRepository);
+    }
+
+    @Test
+    void executeAcceptsProposalAndReturnsResponse() {
+        Long proposalIdVal = 1001L;
+        ProposalId proposalId = ProposalId.of(proposalIdVal);
+
+        // Given a submitted proposal
+        Proposal proposal = Proposal.builder()
+            .proposalId(proposalId)
+            .opportunityId(55L)
+            .companyId(1L)
+            .status(ProposalStatus.SUBMITTED)
+            .price(BigDecimal.valueOf(1000))
+            .build();
+
+        when(proposalRepository.findById(proposalId)).thenReturn(Mono.just(proposal));
+        when(proposalRepository.save(any(Proposal.class))).thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        StepVerifier.create(useCase.execute(proposalIdVal))
+            .assertNext(response -> {
+                assertThat(response).isInstanceOf(ProposalResponse.class);
+                assertThat(response.proposalId()).isEqualTo(proposalIdVal);
+                assertThat(response.status()).isEqualTo(ProposalStatus.ACCEPTED.name());
+            })
+            .verifyComplete();
+
+        verify(proposalRepository).findById(proposalId);
+        verify(proposalRepository).save(any(Proposal.class));
+    }
+
+    @Test
+    void executeReturnsErrorWhenProposalNotFound() {
+        Long proposalIdVal = 1001L;
+        ProposalId proposalId = ProposalId.of(proposalIdVal);
+
+        when(proposalRepository.findById(proposalId)).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.execute(proposalIdVal))
+            .verifyComplete(); // Empty Mono returned
+
+        verify(proposalRepository).findById(proposalId);
+    }
+
+    @Test
+    void executeReturnsErrorWhenInvalidStateTransition() {
+        Long proposalIdVal = 1001L;
+        ProposalId proposalId = ProposalId.of(proposalIdVal);
+
+        // Given a proposal that is already withdrawn
+        Proposal proposal = Proposal.builder()
+            .proposalId(proposalId)
+            .opportunityId(55L)
+            .companyId(1L)
+            .status(ProposalStatus.WITHDRAWN)
+            .price(BigDecimal.valueOf(1000))
+            .build();
+
+        when(proposalRepository.findById(proposalId)).thenReturn(Mono.just(proposal));
+
+        StepVerifier.create(useCase.execute(proposalIdVal))
+            .expectError(IllegalStateException.class)
+            .verify();
+
+        verify(proposalRepository).findById(proposalId);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Implemented `AcceptProposalUseCase` logic, replacing a `TODO` comment in `ProposalController`. Added a new interface `AcceptProposalUseCase`, an implementation `AcceptProposalUseCaseImpl`, and comprehensive tests `AcceptProposalUseCaseImplTest`.
💡 **Why:** This clears a missing functionality gap and completes the existing endpoint's behavior. Returning the correctly structured `Mono` and translating domain exceptions keeps the code robust, readable, and properly decoupled (following the Hexagonal Architecture pattern).
✅ **Verification:** Verified that logic perfectly mirrors patterns already established in the codebase. Tests cover successfully accepting a proposal, handling proposals that aren't found, and preventing illegal state transitions.
✨ **Result:** A functioning `/api/v1/proposals/{id}/accept` endpoint mapped properly from the REST adapter down to the domain layer.

---
*PR created automatically by Jules for task [11203026220293683044](https://jules.google.com/task/11203026220293683044) started by @flaviotinococoutinho*