### PR TITLE
🎨 Palette: [UX improvement] Add accessible aria-label to Remove Attribute button

### DIFF
--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -137,6 +137,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
                 className="btn btn-secondary"
                 style={{ padding: '0.25rem 0.5rem' }}
                 title="Remover atributo"
+                aria-label={`Remover atributo ${attr.key || 'novo'}`}
               >
                 <XMarkIcon style={{ width: '16px', height: '16px' }} />
               </button>


### PR DESCRIPTION
💡 What: Added an `aria-label` to the "Remove attribute" icon button in `AttributeEditor.tsx` (found in "Criar pedido" page).
🎯 Why: Icon-only buttons without accessible labels are difficult or impossible for screen reader users to understand. This improves keyboard and screen-reader navigation by explicitly stating which attribute is being removed (e.g. "Remover atributo voltage").
♿ Accessibility: Ensures WCAG compliance for icon-only buttons by providing a descriptive `aria-label`.

---
*PR created automatically by Jules for task [11781014826815014235](https://jules.google.com/task/11781014826815014235) started by @flaviotinococoutinho*