### PR TITLE
🎨 Palette: Add ARIA role="alert" to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+## 2026-04-09 - Added role=alert to inline errors
+**Learning:** Screen readers won't announce dynamically rendered error messages unless they are enclosed in a container with `role="alert"` (or `aria-live`). By standardizing the `errorInline` CSS class across components to include this role, we significantly improved the accessibility of form validations.
+**Action:** Always include `role="alert"` on any container that renders inline validation or submission errors.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` to dynamically rendered `errorInline` messages in `AttributeEditor.tsx`, `EventDetailPage.tsx`, and `CreateEventPage.tsx`.

🎯 Why: To ensure screen readers immediately announce these critical validation and submission errors to users relying on assistive technology when the DOM updates.

📸 Before/After: Visuals remain unchanged; the impact is purely assistive (semantic HTML).

♿ Accessibility: Ensures that dynamically injected error text does not go unnoticed by non-visual users, complying with foundational ARIA live region guidelines.

---
*PR created automatically by Jules for task [12561655966562109776](https://jules.google.com/task/12561655966562109776) started by @flaviotinococoutinho*