### PR TITLE
🎨 Palette: Enhance inline form error accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-24 - Accessibility for Inline Form Errors
+**Learning:** Found several inline error messages (e.g. `errorInline` class used in components like `AttributeEditor`, `CreateEventPage`, `EventDetailPage`) that lacked `role="alert"`. Without this role, screen readers will not immediately notify the user when an asynchronous form validation or API submission fails, making the failure invisible to non-visual users unless they manually navigate back to the error.
+**Action:** Always include `role="alert"` (or `aria-live="assertive"`) on containers that dynamically display inline errors to ensure accessibility.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 **What:** Added `role="alert"` to `errorInline` UI components across `AttributeEditor`, `CreateEventPage`, and `EventDetailPage`. Added a new entry to the palette journal documenting this pattern.
🎯 **Why:** Without `role="alert"`, inline errors generated asynchronously (e.g., from failed API submissions) are entirely invisible to screen readers unless the user manually navigates to them. This ensures immediate feedback for non-visual users.
📸 **Before/After:** (N/A visual changes)
♿ **Accessibility:** Screen readers will now automatically and immediately announce form or submission errors.

---
*PR created automatically by Jules for task [2683033429196932831](https://jules.google.com/task/2683033429196932831) started by @flaviotinococoutinho*