### PR TITLE
🎨 Palette: Add aria-current to Pager and fix strict test localization

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-10-25 - ARIA Current attributes and Localization in Tests
+**Learning:** Adding `aria-current="page"` to the current page indicator in a pagination component is an excellent micro-UX addition for screen readers. However, when writing tests in an app with strict localization (e.g. Portuguese), standard English ARIA conventions (like expecting "Pagination" or "Previous page") will cause tests to fail. The tests must assert the exact localized strings.
+**Action:** Ensure that any ARIA attributes added to generic components correctly respect the localization language of the application (e.g., Portuguese "Paginação" instead of "Pagination") and that unit tests match these strings exactly.

--- a/frontend/mkt-reverse-web/src/ui/components/Pager.test.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/Pager.test.tsx
@@ -7,12 +7,12 @@ describe('Pager UX/A11y', () => {
     render(<Pager page={1} totalPages={5} onPrev={vi.fn()} onNext={vi.fn()} />)
 
     const nav = screen.getByRole('navigation')
-    expect(nav.getAttribute('aria-label')).toBe('Pagination')
+    expect(nav.getAttribute('aria-label')).toBe('Paginação')
 
-    const prevBtn = screen.getByLabelText('Previous page')
+    const prevBtn = screen.getByLabelText('Página anterior')
     expect(prevBtn).toBeDefined()
 
-    const nextBtn = screen.getByLabelText('Next page')
+    const nextBtn = screen.getByLabelText('Próxima página')
     expect(nextBtn).toBeDefined()
 
     const current = screen.getByText('page')

--- a/frontend/mkt-reverse-web/src/ui/components/Pager.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/Pager.tsx
@@ -22,7 +22,7 @@ export function Pager({ page, totalPages, onPrev, onNext }: Props) {
       >
         ←
       </button>
-      <div className="pagerText" aria-live="polite">
+      <div className="pagerText" aria-live="polite" aria-current="page">
         <span className="mono">page</span> {page + 1} <span className="muted">/ {totalPages || 1}</span>
       </div>
       <button


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to the pagination text and corrected test strings to exactly match the Portuguese localization.
🎯 Why: Enhances screen reader context by explicitly stating which text represents the current page, and fixes a failing unit test in `Pager.test.tsx` that incorrectly expected English strings ("Pagination", "Previous page", etc).
📸 Before/After: Visual changes are not impactful, but structural semantics are drastically improved for a11y, and tests now pass cleanly.
♿ Accessibility: Uses `aria-current="page"` properly inside a pagination component.

---
*PR created automatically by Jules for task [12876266705759843109](https://jules.google.com/task/12876266705759843109) started by @flaviotinococoutinho*