### PR TITLE
🎨 Palette: Add empty state to SupplierDirectoryPage

### DIFF
--- a/frontend/mkt-reverse-web/src/ui/pages/SupplierDirectoryPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/SupplierDirectoryPage.tsx
@@ -128,6 +128,13 @@ export function SupplierDirectoryPage() {
         </div>
       </section>
 
+      {rows.length === 0 ? (
+        <div className="panel" role="alert" aria-live="polite">
+          <div className="panelBody" style={{ textAlign: 'center', padding: '2rem' }}>
+            <p className="muted">Nenhum fornecedor encontrado para os filtros selecionados.</p>
+          </div>
+        </div>
+      ) : (
       <section className="grid" aria-label="Supplier results">
         {rows.map((s) => (
           <article key={s.id} className="card">
@@ -158,6 +165,7 @@ export function SupplierDirectoryPage() {
           </article>
         ))}
       </section>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
🎨 Palette: Add empty state to SupplierDirectoryPage

💡 What: Added a clear empty state message when no suppliers are found in the directory.
🎯 Why: Prevents a blank screen and provides immediate feedback to the user when filters return no results.
♿ Accessibility: The empty state uses `role="alert"` and `aria-live="polite"` so screen readers announce it.

---
*PR created automatically by Jules for task [2064931448174271323](https://jules.google.com/task/2064931448174271323) started by @flaviotinococoutinho*