### PR TITLE
🎨 Palette: Add aria-atomic to pagination controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2026-05-06 - Add aria-atomic to dynamic text in aria-live regions
+**Learning:** When using `aria-live` on regions with dynamic text (like pagination counters 'page 1 / 5'), if only a part of the text changes (e.g. the number 1 to 2), screen readers might only announce the isolated change rather than the full context. Also, `aria-current="page"` is meant for interactive active links, not plain text containers.
+**Action:** Use `aria-atomic="true"` on `aria-live` dynamic text regions to ensure screen readers read the full state change. Avoid using `aria-current="page"` on non-navigational plain text elements.

--- a/frontend/mkt-reverse-web/src/ui/components/Pager.test.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/Pager.test.tsx
@@ -7,15 +7,16 @@ describe('Pager UX/A11y', () => {
     render(<Pager page={1} totalPages={5} onPrev={vi.fn()} onNext={vi.fn()} />)
 
     const nav = screen.getByRole('navigation')
-    expect(nav.getAttribute('aria-label')).toBe('Pagination')
+    expect(nav.getAttribute('aria-label')).toBe('Paginação')
 
-    const prevBtn = screen.getByLabelText('Previous page')
+    const prevBtn = screen.getByLabelText('Página anterior')
     expect(prevBtn).toBeDefined()
 
-    const nextBtn = screen.getByLabelText('Next page')
+    const nextBtn = screen.getByLabelText('Próxima página')
     expect(nextBtn).toBeDefined()
 
     const current = screen.getByText('page')
-    expect(current.parentElement?.getAttribute('aria-current')).toBe('page')
+    expect(current.parentElement?.getAttribute('aria-live')).toBe('polite')
+    expect(current.parentElement?.getAttribute('aria-atomic')).toBe('true')
   })
 })

--- a/frontend/mkt-reverse-web/src/ui/components/Pager.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/Pager.tsx
@@ -22,7 +22,7 @@ export function Pager({ page, totalPages, onPrev, onNext }: Props) {
       >
         ←
       </button>
-      <div className="pagerText" aria-live="polite">
+      <div className="pagerText" aria-live="polite" aria-atomic="true">
         <span className="mono">page</span> {page + 1} <span className="muted">/ {totalPages || 1}</span>
       </div>
       <button


### PR DESCRIPTION
Added the `aria-atomic="true"` attribute to the dynamically updating `aria-live="polite"` pagination text region in `Pager.tsx`. To ensure screen readers announce the full pagination state (e.g. "page 2 / 5") instead of just the isolated number that changes, providing better context for visually impaired users. Improves how screen readers handle dynamic text updates in live regions, and correctly aligns with localization requirements.

---
*PR created automatically by Jules for task [7230124108849103842](https://jules.google.com/task/7230124108849103842) started by @flaviotinococoutinho*