### PR TITLE
🎨 Palette: Add ARIA roles to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-24 - Accessibility for Inline Error Messages
+**Learning:** In the frontend React application (`frontend/mkt-reverse-web`), inline error messages (often styled with the `errorInline` class) lack accessibility attributes by default. This prevents screen readers from properly announcing asynchronous validation or submission failures.
+**Action:** Ensure inline error message containers include `role="alert"` and `aria-live="assertive"` so that error feedback is immediately conveyed to screen reader users.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
🎨 **Palette: Accessibility for Inline Error Messages**

💡 **What:** Added `role="alert"` and `aria-live="assertive"` to components using `className="errorInline"`.
🎯 **Why:** To ensure that dynamic, asynchronous error messages (like validation failures or submission errors) are proactively announced by screen readers.
♿ **Accessibility:** This simple micro-UX fix directly impacts users relying on screen readers who would otherwise miss critical feedback.

**Files changed:**
* `AttributeEditor.tsx`
* `EventDetailPage.tsx`
* `CreateEventPage.tsx`
* Added learning to `.Jules/palette.md`

---
*PR created automatically by Jules for task [8030686652474935687](https://jules.google.com/task/8030686652474935687) started by @flaviotinococoutinho*