### PR TITLE
🎨 Palette: Accessible Inline Error Messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-25 - Accessible Inline Error Messages
+**Learning:** Inline error messages for async operations or dynamic lists lack default accessibility attributes. Without them, screen readers may completely miss asynchronous failure feedback, leaving visually impaired users unaware of validation or submission errors.
+**Action:** Always add `role="alert"` and `aria-live="assertive"` to elements displaying dynamic, inline error messages (e.g., those using the `errorInline` class) so screen readers can announce them immediately when they appear.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
As a UX-focused enhancement, this PR makes inline error messages (`.errorInline` elements) accessible to screen readers by adding `role="alert"` and `aria-live="assertive"`. This is crucial for forms where errors are displayed dynamically without a full page reload, ensuring all users are notified of submission or validation failures. Affected components are `AttributeEditor`, `CreateEventPage`, and `EventDetailPage`.

A journal entry has been added to `.Jules/palette.md` documenting this accessibility learning.

---
*PR created automatically by Jules for task [2062748812875314058](https://jules.google.com/task/2062748812875314058) started by @flaviotinococoutinho*