### PR TITLE
🎨 Palette: Accessible Inline Errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-03 - Accessible Inline Errors
+**Learning:** Inline error messages (often styled with the `errorInline` class) lack accessibility attributes by default, preventing screen readers from announcing asynchronous validation or submission failures.
+**Action:** Ensure inline error messages include `role="alert"` and `aria-live="assertive"` to properly announce failures to screen readers.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div role="alert" aria-live="assertive" className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}


### PR DESCRIPTION
💡 What: Added `role='alert'` and `aria-live='assertive'` to inline error messages in `AttributeEditor`.\n🎯 Why: Ensures screen readers announce asynchronous validation or submission failures.\n♿ Accessibility: Screen reader users will now be notified immediately when an error occurs.

---
*PR created automatically by Jules for task [12586293612397586904](https://jules.google.com/task/12586293612397586904) started by @flaviotinococoutinho*