### PR TITLE
🎨 Palette: Improve accessibility for inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-24 - Accessibility of Inline Error Messages
+**Learning:** Found that inline error messages (`.errorInline` elements) used to display validation or submission errors were missing accessibility attributes, making it difficult for screen readers to announce asynchronous failures.
+**Action:** Always add `role="alert"` and `aria-live="assertive"` to inline error message containers so screen readers properly announce asynchronous validation or submission errors to users without requiring them to shift focus manually.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div role="alert" aria-live="assertive" className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div role="alert" aria-live="assertive" className="errorInline">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div role="alert" aria-live="assertive" className="errorInline">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to `.errorInline` elements in `AttributeEditor`, `EventDetailPage`, and `CreateEventPage`. Also recorded the learning in `.Jules/palette.md`.
🎯 Why: Inline error messages generated from asynchronous operations (like form submissions or dynamic validations) are not automatically announced by screen readers. Adding these ARIA attributes ensures the errors are asserted immediately.
♿ Accessibility: Ensures that screen reader users are notified when asynchronous errors occur without needing to manually find the error text.

---
*PR created automatically by Jules for task [16254504027172370200](https://jules.google.com/task/16254504027172370200) started by @flaviotinococoutinho*