### PR TITLE
🎨 Palette: Add ARIA alert roles to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-02 - Accessible Inline Error Messages
+**Learning:** Inline error messages (styled with the `errorInline` class) lack accessibility attributes by default. Without these, asynchronous validation or submission failures are not announced to screen readers, leaving users unaware of the issue.
+**Action:** Always ensure that dynamic error message containers, such as those using the `errorInline` class, include `role="alert"` and `aria-live="assertive"` to properly announce failures to screen readers.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
* 💡 What: Added `role="alert"` and `aria-live="assertive"` to `.errorInline` divs across `AttributeEditor.tsx`, `EventDetailPage.tsx`, and `CreateEventPage.tsx`. Also appended a UX learning to `.Jules/palette.md`.
* 🎯 Why: To ensure asynchronous validation or submission failures are properly and immediately announced to screen readers.
* 📸 Before/After: Visual changes are not applicable.
* ♿ Accessibility: Significantly improved screen reader accessibility for dynamic, inline error messaging.

---
*PR created automatically by Jules for task [8330424506957372880](https://jules.google.com/task/8330424506957372880) started by @flaviotinococoutinho*