### PR TITLE
🎨 Palette: Add accessible alert roles to inline errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2026-06-07 - Add Accessible Alert Roles to Inline Errors
+**Learning:** Inline error messages (often styled with the `errorInline` class) may lack accessibility attributes by default, failing to announce asynchronous validation or submission failures to screen readers.
+**Action:** Ensure they include `role="alert"` and `aria-live="assertive"` to properly announce asynchronous validation or submission failures to screen readers.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` attributes to inline error messages (elements utilizing the `errorInline` class) across multiple UI components and pages (`AttributeEditor`, `CreateEventPage`, `EventDetailPage`).

🎯 Why: Inline error messages dynamically appear when asynchronous validation or form submission fails. Without explicit ARIA live regions, screen readers do not automatically announce these new errors to the user, leading to a confusing and inaccessible experience where the user might not realize an action failed.

📸 Before/After: Visual presentation is completely unchanged. Screen reader behavior changed from silent failures to immediate assertive announcements.

♿ Accessibility: Significantly improves screen reader support for critical error states by ensuring dynamic failure text is read aloud immediately via assertive live regions.

---
*PR created automatically by Jules for task [1495327173380348669](https://jules.google.com/task/1495327173380348669) started by @flaviotinococoutinho*