### PR TITLE
🎨 Palette: Make inline asynchronous error messages screen-reader friendly

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-08 - ARIA attributes on inline asynchronous errors
+**Learning:** Found that inline asynchronous error messages (like `errorInline` used for form submission failures or dynamic validation errors) were not being announced to screen readers because they lacked semantic alerting attributes.
+**Action:** When creating or modifying inline error messages that appear asynchronously, always ensure they are wrapped in an element with `role="alert"` and `aria-live="assertive"` so that assistive technologies announce them immediately when they appear on the screen.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What:
Added semantic `role="alert"` and `aria-live="assertive"` attributes to all `errorInline` elements across the application (`AttributeEditor`, `CreateEventPage`, `EventDetailPage`).

🎯 Why:
Inline error messages that appear asynchronously (e.g., after an API request fails or dynamic validation triggers) were not being announced to screen readers. Users relying on assistive technologies were unaware that an error had occurred or what it was.

📸 Before/After:
Before: `<div className="errorInline">Erro ao criar pedido</div>` (Silently appears on screen)
After: `<div className="errorInline" role="alert" aria-live="assertive">Erro ao criar pedido</div>` (Immediately announced by screen reader)

♿ Accessibility:
Dramatically improves the form submission and validation experience for screen reader users by ensuring error feedback is immediately conveyed without requiring them to manually re-navigate the page to find it.

---
*PR created automatically by Jules for task [6222025339568426080](https://jules.google.com/task/6222025339568426080) started by @flaviotinococoutinho*