### PR TITLE
🎨 Palette: [UX improvement] Make inline error messages accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-11 - Accessible Inline Errors
+**Learning:** Inline error messages (styled with `.errorInline`) rendered conditionally upon form submission or validation failure often lack accessibility attributes, meaning they are visually present but not announced by screen readers.
+**Action:** Always ensure that dynamically rendered inline error messages include `role="alert"` and `aria-live="assertive"` to properly announce asynchronous validation or submission failures to screen readers.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
**💡 What:** 
Added `role="alert"` and `aria-live="assertive"` to all `.errorInline` elements that render conditionally (e.g., when a form mutation fails).

**🎯 Why:** 
Currently, inline validation and submission errors are styled visually in red but lack proper ARIA attributes. A screen reader user might submit a form and, if it fails, not be notified of the failure because the dynamic DOM change isn't announced.

**📸 Before/After:**
*Before:* `<div className="errorInline">Erro ao criar pedido.</div>`
*After:* `<div className="errorInline" role="alert" aria-live="assertive">Erro ao criar pedido.</div>`

**♿ Accessibility:** 
Improves compliance with WCAG dynamic content guidelines. Screen readers will now reliably interrupt and announce asynchronous form submission failures and inline validation errors immediately as they appear.

Also added a journal entry in `.Jules/palette.md` for this accessible pattern.

---
*PR created automatically by Jules for task [2798707265591516159](https://jules.google.com/task/2798707265591516159) started by @flaviotinococoutinho*