### PR TITLE
🎨 Palette: [UX improvement] Add ARIA alert roles to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-12 - Inline Error Messages Need ARIA Alert Role
+**Learning:** Found several inline error messages styled with `errorInline` in forms (like in `AttributeEditor.tsx`, `CreateEventPage.tsx`, and `EventDetailPage.tsx`) that appear asynchronously upon validation or submission failures but lacked accessibility attributes. Screen readers would not announce these errors when they appeared, leaving users unaware of the failure.
+**Action:** When adding inline error messages that appear dynamically without a page load, ensure they include `role="alert"` and `aria-live="assertive"` so that the screen reader immediately interrupts the user to announce the failure.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to `.errorInline` elements across the application (e.g., AttributeEditor, CreateEventPage, EventDetailPage).
🎯 Why: Asynchronous inline error messages generated from validation or submission failures were appearing visually but lacked the necessary attributes to be announced by screen readers, leaving visually impaired users unaware of failures.
📸 Before/After: Visuals remain unchanged, but the DOM now includes `role="alert" aria-live="assertive"` on error containers.
♿ Accessibility: Screen readers will now immediately interrupt and announce inline error messages when they dynamically render on the page.

---
*PR created automatically by Jules for task [10698458278029432542](https://jules.google.com/task/10698458278029432542) started by @flaviotinococoutinho*