### PR TITLE
🎨 Palette: Add ARIA accessibility attributes to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-13 - Add ARIA Roles to Inline Errors
+**Learning:** Found several inline error messages styled with `errorInline` that lacked accessibility attributes. These messages appear asynchronously during form submission or validation. Without proper ARIA roles, screen readers won't announce these failures automatically.
+**Action:** Always include `role="alert"` and `aria-live="assertive"` on containers that dynamically display error messages (like `errorInline` components) to ensure asynchronous failures are properly announced to screen reader users.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to instances of the `errorInline` class in `AttributeEditor.tsx`, `EventDetailPage.tsx`, and `CreateEventPage.tsx`. Also added a journal entry to `.Jules/palette.md`.
🎯 Why: These error messages appear asynchronously during form submission or validation. Without proper ARIA roles, screen readers won't announce these failures automatically, leaving visually impaired users unaware of the errors.
📸 Before/After: Visual changes are non-existent.
♿ Accessibility: Ensures asynchronous validation and submission failures are properly announced to screen reader users.

---
*PR created automatically by Jules for task [17917867931584721959](https://jules.google.com/task/17917867931584721959) started by @flaviotinococoutinho*