### PR TITLE
🎨 Palette: [UX improvement] Enhance pagination accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-14 - Semantic Usage of aria-current and aria-atomic in Pagination
+**Learning:** Found a component test that incorrectly asserted `aria-current="page"` on a non-interactive, purely informational text container (`<div class="pagerText">page 1 / 5</div>`). Additionally, the `aria-live` region updating the page numbers lacked `aria-atomic="true"`, causing screen readers to potentially announce only the changed number instead of the full context ("page 2 / 5").
+**Action:** When implementing pagination, apply `aria-current="page"` only to interactive semantic navigation items (like the active page link or button). For dynamic text counters inside `aria-live` regions, always add `aria-atomic="true"` to ensure the whole phrase is announced coherently when the count changes.

--- a/frontend/mkt-reverse-web/src/ui/components/Pager.test.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/Pager.test.tsx
@@ -7,15 +7,17 @@ describe('Pager UX/A11y', () => {
     render(<Pager page={1} totalPages={5} onPrev={vi.fn()} onNext={vi.fn()} />)
 
     const nav = screen.getByRole('navigation')
-    expect(nav.getAttribute('aria-label')).toBe('Pagination')
+    expect(nav.getAttribute('aria-label')).toBe('Paginação')
 
-    const prevBtn = screen.getByLabelText('Previous page')
+    const prevBtn = screen.getByLabelText('Página anterior')
     expect(prevBtn).toBeDefined()
 
-    const nextBtn = screen.getByLabelText('Next page')
+    const nextBtn = screen.getByLabelText('Próxima página')
     expect(nextBtn).toBeDefined()
 
     const current = screen.getByText('page')
-    expect(current.parentElement?.getAttribute('aria-current')).toBe('page')
+    const parent = current.parentElement
+    expect(parent?.getAttribute('aria-live')).toBe('polite')
+    expect(parent?.getAttribute('aria-atomic')).toBe('true')
   })
 })

--- a/frontend/mkt-reverse-web/src/ui/components/Pager.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/Pager.tsx
@@ -22,7 +22,7 @@ export function Pager({ page, totalPages, onPrev, onNext }: Props) {
       >
         ←
       </button>
-      <div className="pagerText" aria-live="polite">
+      <div className="pagerText" aria-live="polite" aria-atomic="true">
         <span className="mono">page</span> {page + 1} <span className="muted">/ {totalPages || 1}</span>
       </div>
       <button


### PR DESCRIPTION
💡 What: Added `aria-atomic="true"` to the `aria-live` region in `Pager.tsx` and removed a semantically incorrect `aria-current` assertion from `Pager.test.tsx`, correcting it to assert Portuguese strings.

🎯 Why: When dynamic page numbers change (e.g., going from "page 1 / 5" to "page 2 / 5"), screen readers might only announce "2" without `aria-atomic="true"`. Adding it ensures the entire descriptive string is announced, providing vital context for users. Additionally, `aria-current="page"` belongs on interactive elements like current page buttons, not plain text containers.

📸 Before/After: Not applicable (invisible semantic change).

♿ Accessibility: Ensures full context is provided for live region updates on pagination text. Validated the components use appropriate structural and language-specific labels ('Paginação', 'Página anterior').

---
*PR created automatically by Jules for task [3508193236776186824](https://jules.google.com/task/3508193236776186824) started by @flaviotinococoutinho*