### PR TITLE
🎨 Palette: [UX improvement] Make inline error messages accessible to screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2026-06-16 - Inline Error Messages Without ARIA Alerts
+**Learning:** Discovered that inline error messages (specifically those using the `errorInline` class) across multiple components (`AttributeEditor`, `CreateEventPage`, `EventDetailPage`) lacked `role="alert"` and `aria-live="assertive"`, preventing screen readers from automatically announcing validation failures or submission errors when they appear.
+**Action:** Always ensure that dynamically appearing error messages or validation feedback text blocks include `role="alert"` and `aria-live="assertive"` so that screen reader users are immediately informed of the issue without having to navigate to the error text.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 **What:** Added `role="alert"` and `aria-live="assertive"` to components using the `.errorInline` class (`AttributeEditor.tsx`, `CreateEventPage.tsx`, `EventDetailPage.tsx`).
🎯 **Why:** To ensure that asynchronous validation and form submission errors are proactively announced by screen readers as soon as they appear in the DOM, without requiring the user to manually navigate to the error text.
📸 **Before/After:** Not a visual change. Code changed from `<div className="errorInline">` to `<div className="errorInline" role="alert" aria-live="assertive">`.
♿ **Accessibility:** Fixes a critical accessibility gap where dynamically appearing error messages were visually present but silent to assistive technologies.

---
*PR created automatically by Jules for task [4675075702273478669](https://jules.google.com/task/4675075702273478669) started by @flaviotinococoutinho*