### PR TITLE
🎨 Palette: [UX improvement] Accessible Inline Error Messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-17 - Accessible Inline Error Messages
+**Learning:** Inline error messages (e.g., dynamically rendered validation errors in `.errorInline` containers) are visually apparent but silently ignored by screen readers when they appear asynchronously after initial page load or user interaction.
+**Action:** Ensure dynamic error containers use `role="alert"` and `aria-live="assertive"` so that the text is proactively announced to assistive technology without requiring focus shifts.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}


### PR DESCRIPTION
💡 What:
Added `role="alert"` and `aria-live="assertive"` to the `.errorInline` message container in `AttributeEditor.tsx`.

🎯 Why:
Inline error messages that appear asynchronously (e.g., validation errors after user interaction) are visually apparent but silently ignored by screen readers unless explicitly marked as live regions.

📸 Before/After:
No visual changes.

♿ Accessibility:
Screen readers will now immediately and proactively announce the error message text when it appears, without requiring the user to manually shift focus to the error container.

---
*PR created automatically by Jules for task [14597959071261483163](https://jules.google.com/task/14597959071261483163) started by @flaviotinococoutinho*