### PR TITLE
🎨 Palette: Ensure screen readers announce inline errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-24 - Dynamic ARIA Roles for Inline Error Messages
+**Learning:** Found several inline error messages (`errorInline`) that lacked critical ARIA roles and live regions. Since these errors pop up asynchronously on form validations or API failures, screen readers will not announce them without specific live regions.
+**Action:** When adding or maintaining asynchronous error messages that appear without a page reload (such as `errorInline`), always ensure they are paired with `role="alert"` and `aria-live="assertive"` to enforce immediate announcement to screen reader users.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What:
Added `role="alert"` and `aria-live="assertive"` to asynchronous inline error messages (`.errorInline`) across the frontend UI (specifically in `AttributeEditor.tsx`, `CreateEventPage.tsx`, and `EventDetailPage.tsx`).

🎯 Why:
Inline error messages for API failures or form validations appear asynchronously. Without a live region, screen reader users are unaware that a new error has surfaced.

📸 Before/After:
Before: `<div className="errorInline">Erro ao criar pedido...</div>`
After: `<div className="errorInline" role="alert" aria-live="assertive">Erro ao criar pedido...</div>`

♿ Accessibility:
Enforces immediate and assertive announcements for dynamically injected error messages via screen readers, bringing them up to parity with visual feedback.

---
*PR created automatically by Jules for task [10521324408684750015](https://jules.google.com/task/10521324408684750015) started by @flaviotinococoutinho*