### PR TITLE
🎨 Palette: Add ARIA Roles to Inline Error Messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2026-06-20 - Add ARIA Roles to Inline Error Messages
+**Learning:** Inline error messages (styled with `.errorInline`) displaying dynamic validation or submission failures are easily missed by screen readers if they lack accessibility attributes.
+**Action:** Always ensure that inline error messages contain `role="alert"` and `aria-live="assertive"` so screen readers properly announce asynchronous validation or submission failures to users.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div role="alert" aria-live="assertive" className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div role="alert" aria-live="assertive" className="errorInline">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div role="alert" aria-live="assertive" className="errorInline">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 **What:** 
Added `role="alert"` and `aria-live="assertive"` attributes to inline error messages (elements with `.errorInline` class).

🎯 **Why:**
Inline error messages displaying dynamic validation or asynchronous submission failures are often missed by screen readers if they lack appropriate accessibility attributes. This ensures all users are promptly informed of errors.

📸 **Before/After:**
*Visual change:* None.
*Semantic change:*
Before: `<div className="errorInline">...</div>`
After: `<div role="alert" aria-live="assertive" className="errorInline">...</div>`

♿ **Accessibility:**
Significantly improved accessibility by making inline validation errors immediately noticeable to assistive technologies using standard ARIA live region alerts.

---
*PR created automatically by Jules for task [18050812744472105378](https://jules.google.com/task/18050812744472105378) started by @flaviotinococoutinho*