### PR TITLE
🎨 Palette: [UX improvement] Make inline error messages accessible to screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-22 - Accessible Inline Error Messages
+**Learning:** In the React frontend, components displaying dynamic, asynchronous validation or submission failures using the `.errorInline` class were lacking ARIA live region attributes. Without these, screen readers would not announce the appearance of error messages automatically when they pop up after an interaction like a form submission.
+**Action:** When creating or modifying inline error messages that appear asynchronously, ensure they include `role="alert"` and `aria-live="assertive"` to properly announce failures to screen readers.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` attributes to the `.errorInline` `div` tags used in `AttributeEditor`, `CreateEventPage`, and `EventDetailPage`.
🎯 Why: Asynchronous validation and submission errors rendered into these divs were previously not being automatically announced to visually impaired users because they appeared without ARIA live region semantics.
📸 Before/After: No visual changes; purely semantic additions to HTML.
♿ Accessibility: Ensures that dynamic inline error messages are immediately and assertively announced by screen readers when they appear in the UI.

---
*PR created automatically by Jules for task [16855176894251709712](https://jules.google.com/task/16855176894251709712) started by @flaviotinococoutinho*