### PR TITLE
🎨 Palette: Add accessible alert roles to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-24 - Accessible Inline Error Messages
+**Learning:** Inline error messages (often styled with `errorInline` or displaying dynamic validation/submission errors) are visually apparent but not automatically announced by screen readers when they appear asynchronously.
+**Action:** Always add `role="alert"` and `aria-live="assertive"` to inline error message containers to ensure they are immediately announced to screen reader users when validation fails or async submissions return errors.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 **What:** Added `role="alert"` and `aria-live="assertive"` to inline error messages (`.errorInline`) across the frontend UI (specifically in `AttributeEditor.tsx`, `EventDetailPage.tsx`, and `CreateEventPage.tsx`). Also recorded this pattern in my UX journal.

🎯 **Why:** Inline error messages (like form validation failures or async submission errors) appear dynamically on the screen. While visual users see the red text appear, screen reader users are not automatically notified unless the container has specific ARIA live region attributes.

📸 **Before/After:**
* **Before:** `<div className="errorInline">Erro ao criar pedido.</div>` (Visual only)
* **After:** `<div className="errorInline" role="alert" aria-live="assertive">Erro ao criar pedido.</div>` (Announced by screen readers immediately upon rendering)

♿ **Accessibility:** This directly improves WCAG compliance (Status Messages) by ensuring that users relying on assistive technologies are immediately informed when an asynchronous error occurs, without needing to manually hunt for the new error text on the page.

---
*PR created automatically by Jules for task [3099141642091911303](https://jules.google.com/task/3099141642091911303) started by @flaviotinococoutinho*