### PR TITLE
🎨 Palette: [UX improvement] Enhance screen reader accessibility for dynamic inline errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-28 - ARIA Labels for Inline Errors
+**Learning:** In the frontend React application (`frontend/mkt-reverse-web`), inline error messages (often styled with the `errorInline` class) lack accessibility attributes by default. Without `role="alert"` and `aria-live="assertive"`, asynchronous validation or submission failures are not properly announced to screen readers.
+**Action:** When creating or modifying dynamic inline error messages, always ensure they include `role="alert"` and `aria-live="assertive"` so that the errors are immediately communicated to users of assistive technologies.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div role="alert" aria-live="assertive" className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div role="alert" aria-live="assertive" className="errorInline">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div role="alert" aria-live="assertive" className="errorInline">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to inline error message containers (`.errorInline`) across the frontend UI (AttributeEditor, CreateEventPage, and EventDetailPage). Also documented this accessibility requirement in the Palette journal.
🎯 Why: Without these ARIA attributes, asynchronous validation errors and form submission failures are not properly announced to screen reader users, causing them to miss critical feedback when interactions fail.
📸 Before/After: (Visuals are identical; this is an invisible, purely semantic HTML markup enhancement.)
♿ Accessibility: Screen readers will now immediately read aloud any error messages that dynamically appear in the `.errorInline` containers, significantly improving keyboard and screen reader navigation and error recovery.

---
*PR created automatically by Jules for task [3801116607702257550](https://jules.google.com/task/3801116607702257550) started by @flaviotinococoutinho*