### PR TITLE
🎨 Palette: [UX improvement] Ensure inline errors are announced by screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-29 - Async Inline Errors Lack ARIA Attributes
+**Learning:** Found multiple instances where asynchronous form validation or API errors were displayed via `.errorInline` elements, but these messages were not announced by screen readers because they lacked `role="alert"` and `aria-live="assertive"`.
+**Action:** When adding or modifying inline error messages (`.errorInline` or similar) that appear asynchronously after user interaction (like submit or validation failures), always include `role="alert"` and `aria-live="assertive"` so screen readers immediately notify the user of the error.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to all `.errorInline` dynamic error messages in the frontend.
🎯 Why: Without these attributes, screen reader users would not be notified when asynchronous API errors or validation failures appear on screen after submitting a form or interacting with dynamic lists, creating a confusing experience.
📸 Before/After: Visuals are unchanged. The semantic HTML changed to trigger screen reader alerts.
♿ Accessibility: Vastly improves form and interaction accessibility for visually impaired users by guaranteeing that critical errors are announced immediately as they appear.

---
*PR created automatically by Jules for task [1516053464245022649](https://jules.google.com/task/1516053464245022649) started by @flaviotinococoutinho*