### PR TITLE
🎨 Palette: [UX improvement] Add ARIA alert roles to inline errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-24 - Accessibility for Inline Validation Errors
+**Learning:** In the frontend React application (`frontend/mkt-reverse-web`), inline error messages (like those styled with `.errorInline`) lacked proper ARIA attributes, meaning asynchronous validation or submission failures weren't announced by screen readers.
+**Action:** Ensure that all inline error message containers include `role="alert"` and `aria-live="assertive"` so that error feedback is immediately announced by screen readers when elements are dynamically rendered.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to `.errorInline` elements in the UI.
🎯 Why: To ensure that dynamically rendered, asynchronous error messages (like validation failures) are immediately announced by screen readers.
📸 Before/After: Visuals remain unchanged. Assistive technologies now announce the error when it appears.
♿ Accessibility: Improved screen reader feedback for inline error states, ensuring users are immediately aware when something goes wrong with form submissions or validations.

---
*PR created automatically by Jules for task [6709267409993759173](https://jules.google.com/task/6709267409993759173) started by @flaviotinococoutinho*