### PR TITLE
🎨 Palette: [UX improvement] Add ARIA alert roles to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,11 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## $(date +%Y-%m-%d) - Adding ARIA alert roles to inline error messages
+**Learning:** Inline error messages (styled with `.errorInline`) in React components may lack critical accessibility attributes by default. A recurring pattern here is that dynamic asynchronous feedback (e.g., failed mutations) is rendered without alerting screen readers.
+**Action:** When adding or auditing inline error components, always ensure they include `role="alert"` and `aria-live="assertive"` so visually impaired users immediately hear validation and submission failures.
+
+## 2025-02-12 - Adding ARIA alert roles to inline error messages
+**Learning:** Inline error messages (styled with `.errorInline`) in React components may lack critical accessibility attributes by default. A recurring pattern here is that dynamic asynchronous feedback (e.g., failed mutations) is rendered without alerting screen readers.
+**Action:** When adding or auditing inline error components, always ensure they include `role="alert"` and `aria-live="assertive"` so visually impaired users immediately hear validation and submission failures.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` attributes to all dynamic inline error messages (`.errorInline`) across the frontend UI (AttributeEditor, CreateEventPage, and EventDetailPage).
🎯 Why: When asynchronous operations fail (like form submissions or mutations), the error message is dynamically inserted into the DOM. Without proper ARIA attributes, screen reader users would not be notified of these failures, leaving them confused about why the action didn't succeed.
📸 Before/After: Visuals remain unchanged. Semantically, the elements go from `<div className="errorInline">` to `<div className="errorInline" role="alert" aria-live="assertive">`.
♿ Accessibility: Ensures that dynamic asynchronous errors are immediately announced to visually impaired users by screen readers, improving the overall inclusiveness of the application.

---
*PR created automatically by Jules for task [864694964654857071](https://jules.google.com/task/864694964654857071) started by @flaviotinococoutinho*