### PR TITLE
🎨 Palette: Add screen reader announcements for inline errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-24 - Screen Reader Announcements for Inline Errors
+**Learning:** Inline error messages (styled with `.errorInline`) dynamically appear on asynchronous operations like form submissions or validation failures, but lack implicit ARIA roles, causing screen readers to remain silent when they appear.
+**Action:** Always add `role="alert"` and `aria-live="assertive"` to dynamic inline error containers to ensure that assistive technologies immediately announce the error text to the user upon rendering.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div role="alert" aria-live="assertive" className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div role="alert" aria-live="assertive" className="errorInline">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div role="alert" aria-live="assertive" className="errorInline">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to the `.errorInline` components across the application.

🎯 Why: Inline errors appear dynamically (e.g. upon failed form submission), but without ARIA live regions, screen reader users might not be notified that an error just occurred.

📸 Before/After: Visuals remain unchanged. Assistive technologies now immediately announce the error content.

♿ Accessibility: Ensures that dynamic inline validation and submission errors are proactively announced to screen readers.

---
*PR created automatically by Jules for task [4318116124649115602](https://jules.google.com/task/4318116124649115602) started by @flaviotinococoutinho*