### PR TITLE
🎨 Palette: [UX improvement] Make inline error messages accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-06-25 - Accessible Inline Error Messages
+**Learning:** Found several components using inline error messages styled with `errorInline` (e.g., `AttributeEditor.tsx`, `EventDetailPage.tsx`, `CreateEventPage.tsx`) that lacked ARIA attributes. Without these attributes, async validation or submission failures are not properly announced to screen readers.
+**Action:** Ensure that all inline error messages (especially those appearing asynchronously) include `role="alert"` and `aria-live="assertive"` so that screen reader users are immediately notified of the error.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 **What:** Added `role="alert"` and `aria-live="assertive"` to inline error messages in `AttributeEditor.tsx`, `CreateEventPage.tsx`, and `EventDetailPage.tsx`.
🎯 **Why:** To ensure that asynchronous validation and submission failures are properly announced to screen reader users when they appear dynamically.
📸 **Before/After:** Not applicable (purely semantic/accessibility change).
♿ **Accessibility:** Screen readers will now automatically read out the error messages when they are injected into the DOM upon async errors, greatly improving the experience for visually impaired users.

---
*PR created automatically by Jules for task [7262565378293504055](https://jules.google.com/task/7262565378293504055) started by @flaviotinococoutinho*