### PR TITLE
🎨 Palette: [UX improvement] Improve inline error accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-05-24 - Inline Error Message Accessibility
+**Learning:** In the frontend React application, inline error messages (often styled with the `errorInline` class) may lack accessibility attributes by default. Without `role="alert"` and `aria-live="assertive"`, screen reader users might not be informed of asynchronous validation or submission failures.
+**Action:** Ensure that all inline error messages use `role="alert"` and `aria-live="assertive"` to properly announce failures to screen readers.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to inline error messages (`.errorInline`) in `AttributeEditor.tsx`, `EventDetailPage.tsx`, and `CreateEventPage.tsx`. Also documented this accessibility pattern in the Palette journal.
🎯 Why: Inline error messages generated from asynchronous operations (like form submissions or API failures) were not being automatically announced to screen reader users.
📸 Before/After: No visual changes.
♿ Accessibility: Screen readers will now proactively interrupt and read out inline error messages the moment they appear on screen, drastically improving the experience for visually impaired users.

---
*PR created automatically by Jules for task [5643036812966633218](https://jules.google.com/task/5643036812966633218) started by @flaviotinococoutinho*