### PR TITLE
🎨 Palette: Add ARIA roles to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2024-07-07 - Add ARIA Roles and Live Regions to Inline Error Messages
+**Learning:** In the frontend React application (`frontend/mkt-reverse-web`), inline error messages (often styled with the `errorInline` class) may lack accessibility attributes by default. Without `role="alert"` and `aria-live="assertive"`, asynchronous validation or submission failures are not properly announced to screen readers.
+**Action:** When working on form validations or inline API error displays, ensure that the error container includes `role="alert"` and `aria-live="assertive"` so screen reader users are immediately informed of the issue.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div className="errorInline" role="alert" aria-live="assertive" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div className="errorInline" role="alert" aria-live="assertive">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div className="errorInline" role="alert" aria-live="assertive">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to `.errorInline` elements in `AttributeEditor.tsx`, `CreateEventPage.tsx`, and `EventDetailPage.tsx`.
🎯 Why: Without these attributes, screen reader users might miss critical asynchronous validation or submission errors that appear dynamically in the UI without a page reload or focus change.
📸 Before/After: N/A (Purely semantic accessibility change, no visual difference).
♿ Accessibility: Ensures that dynamic inline error messages are immediately and assertively announced to assistive technologies.

---
*PR created automatically by Jules for task [16523918922440479776](https://jules.google.com/task/16523918922440479776) started by @flaviotinococoutinho*