### PR TITLE
🎨 Palette: [UX improvement] Add ARIA roles to inline error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Dynamic ARIA Labels in Attribute Lists
 **Learning:** When dealing with dynamic lists of inputs (like key-value attribute editors), icon-only remove buttons need specific, dynamic `aria-label`s (e.g., "Remove attribute Size") rather than generic ones ("Remove attribute") so screen reader users know exactly which item they are deleting.
 **Action:** Always interpolate the item's identifying value into the `aria-label` for list item actions.
+
+## 2025-02-14 - Add ARIA Roles to Inline Error Messages
+**Learning:** Found multiple components utilizing inline error messages (styled with the `errorInline` class) to display asynchronous form validation or submission failures without `role="alert"` and `aria-live="assertive"`. This makes these dynamic error messages completely inaccessible to screen reader users, who won't be notified when a form submission fails.
+**Action:** When adding inline error messages that appear dynamically (like after a failed async mutation), always ensure they include `role="alert"` and `aria-live="assertive"` so that assistive technologies immediately announce the failure.

--- a/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
+++ b/frontend/mkt-reverse-web/src/ui/components/AttributeEditor.tsx
@@ -56,7 +56,7 @@ export function AttributeEditor({ attributes, onChange, error }: AttributeEditor
       </h3>
 
       {error && (
-        <div className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
+        <div role="alert" aria-live="assertive" className="errorInline" style={{ marginBottom: '1rem', padding: '0.75rem', background: '#fee2e2', borderRadius: '4px' }}>
           {error}
         </div>
       )}

--- a/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/CreateEventPage.tsx
@@ -247,7 +247,7 @@ export function CreateEventPage() {
               {mutation.isPending ? 'Criando…' : 'Criar pedido'}
             </button>
             {mutation.isError && (
-              <div className="errorInline">
+              <div role="alert" aria-live="assertive" className="errorInline">
                 Erro ao criar pedido. Tente novamente.
               </div>
             )}

--- a/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
+++ b/frontend/mkt-reverse-web/src/ui/pages/EventDetailPage.tsx
@@ -299,7 +299,7 @@ export function EventDetailPage() {
                 {submitM.isPending ? 'Enviando…' : 'Enviar Proposta'}
               </button>
               {submitM.isError && (
-                <div className="errorInline">{String((submitM.error as any)?.message)}</div>
+                <div role="alert" aria-live="assertive" className="errorInline">{String((submitM.error as any)?.message)}</div>
               )}
             </div>
           </form>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to `.errorInline` elements in `AttributeEditor`, `CreateEventPage`, and `EventDetailPage`.

🎯 Why: These inline error messages appear dynamically when asynchronous form submissions or validations fail. Without these ARIA attributes, screen reader users receive no feedback that an error occurred.

📸 Before/After: Visuals remain unchanged. Assistive technology now successfully reads the error text upon dynamic insertion.

♿ Accessibility: Ensures compliance with WCAG dynamic content updates. Screen readers now announce the error messages immediately, making the form interactions accessible.

---
*PR created automatically by Jules for task [9841782080109693963](https://jules.google.com/task/9841782080109693963) started by @flaviotinococoutinho*